### PR TITLE
Reimplement SCS in terms of conv2d

### DIFF
--- a/compat_test.py
+++ b/compat_test.py
@@ -1,0 +1,17 @@
+import torch
+
+from sharpened_cosine_similarity import SharpenedCosineSimilarity, SharpenedCosineSimilarity_ConvImpl
+
+def test():
+    original = SharpenedCosineSimilarity(5, 5, 3)
+    faster = SharpenedCosineSimilarity_ConvImpl(5, 5, 3)
+    faster.load_state_dict(original.state_dict())
+
+    test_values = torch.randn(1, 5, 32, 32)
+
+    orig_output = original(test_values)
+    faster_output = faster(test_values)
+
+    print((orig_output - faster_output).abs().max().item())
+
+test()

--- a/sharpened_cosine_similarity.py
+++ b/sharpened_cosine_similarity.py
@@ -156,9 +156,10 @@ class SharpenedCosineSimilarity_ConvImpl(nn.Module):
 
         q_sqr = (self.q / self.q_scale) ** 2
 
-        # a small difference: we omit the eps parameter since self.q ** 2 will be
-        # positive
-        w_normed = w / (w_norm + q_sqr)
+        # a small difference: we add eps outside of the norm
+        # instead of inside in order to reuse the performant
+        # code of torch.linalg.vector_norm
+        w_normed = w / ((w_norm + self.eps) + q_sqr)
 
         x_norm_squared = F.avg_pool2d(
             x ** 2,
@@ -176,7 +177,7 @@ class SharpenedCosineSimilarity_ConvImpl(nn.Module):
             padding=self.padding,
         )
 
-        y = y_denorm / (x_norm_squared.sqrt() + q_sqr)
+        y = y_denorm / ((x_norm_squared + self.eps).sqrt() + q_sqr)
 
         sign = torch.sign(y)
 

--- a/sharpened_cosine_similarity.py
+++ b/sharpened_cosine_similarity.py
@@ -20,7 +20,6 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-
 class SharpenedCosineSimilarity(nn.Module):
     def __init__(
         self,
@@ -101,3 +100,87 @@ def unfold2d(x, kernel_size:int, stride:int, padding:int):
         (bs, in_c, (h - ks) // stride + 1, (w - ks) // stride + 1, ks, ks),
         (in_c * h * w, h * w, stride * w, stride, w, 1))
     return strided_x
+
+import torch.nn.functional as F
+
+class SharpenedCosineSimilarity_ConvImpl(nn.Module):
+    def __init__(
+        self,
+        in_channels=1,
+        out_channels=1,
+        kernel_size=1,
+        stride=1,
+        padding=0,
+        eps=1e-12,
+    ):
+        super(SharpenedCosineSimilarity_ConvImpl, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.eps = eps
+        self.padding = int(padding)
+
+        w = torch.empty(out_channels, in_channels, kernel_size, kernel_size)
+        nn.init.xavier_uniform_(w)
+        # TODO: this could be initialized as
+        # (out_channels, in_channel, kernel_size, kernel_size)
+        # right off the bat, but we leave it in this format to retain compat
+        # with the einsum implementation
+        self.w = nn.Parameter(
+            w.view(out_channels, in_channels, -1), requires_grad=True)
+
+        self.p_scale = 10
+        p_init = 2**.5 * self.p_scale
+        self.register_parameter("p", nn.Parameter(torch.empty(out_channels)))
+        nn.init.constant_(self.p, p_init)
+
+        self.q_scale = 100
+        self.register_parameter("q", nn.Parameter(torch.empty(1)))
+        nn.init.constant_(self.q, 10)
+
+    def forward(self, x):
+        # reshaping for compatibility with the einsum-based implementation
+        w = self.w.reshape(
+            self.out_channels,
+            self.in_channels,
+            self.kernel_size,
+            self.kernel_size,
+        )
+        w_norm = torch.linalg.vector_norm(
+            w,
+            dim=(1, 2, 3),
+            keepdim=True,
+        )
+
+        q_sqr = (self.q / self.q_scale) ** 2
+
+        # a small difference: we omit the eps parameter since self.q ** 2 will be
+        # positive
+        w_normed = w / (w_norm + q_sqr)
+
+        x_norm_squared = F.avg_pool2d(
+            x ** 2,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            divisor_override=1, # we actually want sum_pool
+        ).sum(dim=1, keepdim=True)
+
+        y_denorm = F.conv2d(
+            x,
+            w_normed,
+            bias=None,
+            stride=self.stride,
+            padding=self.padding,
+        )
+
+        y = y_denorm / (x_norm_squared.sqrt() + q_sqr)
+
+        sign = torch.sign(y)
+
+        y = torch.abs(y) + self.eps
+        p_sqr = (self.p / self.p_scale) ** 2
+        y = y.pow(p_sqr.reshape(1, -1, 1, 1))
+        return sign * y


### PR DESCRIPTION
This PR proposes a change in implementation of SCS which uses Conv2D, a much more performant primitive. The gist of the idea is to 
1. Normalize the kernel as we already do
2. Compute per-window normalization factor coming from the image by `sqrt(avg_pool2d(input ** 2) * window_size)`
3. Compute the dot products via `conv2d` between the input and normalized kernel
4. Normalize the output elementwise by the array obtained in step 2.
5. Proceed as before

On my laptop this achieves more than 2x performance improvement. I attach a quick test (`compat_test.py`) to verify that the two implementations yield (almost) the same results. This PR will obviously need some code unification and renaming before being merged, I submit it as it to facilitate easy comparisons by the maintainers :)