### PR TITLE
Single alpha per layer. Defaults changed.

### DIFF
--- a/pytorch/demo_cifar10.py
+++ b/pytorch/demo_cifar10.py
@@ -71,7 +71,6 @@ class Network(nn.Module):
         self.scs1 = SharpenedCosineSimilarity(
             in_channels=n_input_channels,
             out_channels=n_units_1,
-            bias=True,
             kernel_size=5,
             padding=0)
         self.pool1 = MaxAbsPool2d(kernel_size=2, stride=2, ceil_mode=True)
@@ -79,7 +78,6 @@ class Network(nn.Module):
         self.scs2 = SharpenedCosineSimilarity(
             in_channels=n_units_1,
             out_channels=n_units_2,
-            bias=True,
             kernel_size=5,
             padding=1)
         self.pool2 = MaxAbsPool2d(kernel_size=2, stride=2, ceil_mode=True)
@@ -87,7 +85,6 @@ class Network(nn.Module):
         self.scs3 = SharpenedCosineSimilarity(
             in_channels=n_units_2,
             out_channels=n_units_3,
-            bias=True,
             kernel_size=5,
             padding=1)
         self.pool3 = MaxAbsPool2d(kernel_size=4, stride=4, ceil_mode=True)

--- a/pytorch/demo_fashion_mnist.py
+++ b/pytorch/demo_fashion_mnist.py
@@ -15,8 +15,8 @@ from tqdm import tqdm
 from absolute_pooling import MaxAbsPool2d
 from sharpened_cosine_similarity import SharpCosSim2d
 
-batch_size = 64
-max_lr = .01
+batch_size = 100
+max_lr = .03
 n_classes = 10
 n_epochs = 100
 n_runs = 10
@@ -69,31 +69,31 @@ class Network(nn.Module):
         super().__init__()
 
         self.scs1 = SharpCosSim2d(
-            n_channels_in=n_input_channels,
-            n_kernels=n_kernels_in,
+            in_channels=n_input_channels,
+            out_channels=n_kernels_in,
             kernel_size=kernel_size,
             padding=1)
         self.pool1 = MaxAbsPool2d(kernel_size=2, stride=2)
 
         self.scs2_depth = SharpCosSim2d(
-            n_channels_in=n_kernels_in,
-            n_kernels=n_kernels_in,
+            in_channels=n_kernels_in,
+            out_channels=n_kernels_in,
             kernel_size=kernel_size,
-            depthwise=True)
+            groups=n_kernels_in)
         self.scs2_point = SharpCosSim2d(
-            n_channels_in=n_kernels_in,
-            n_kernels=n_kernels,
+            in_channels=n_kernels_in,
+            out_channels=n_kernels,
             kernel_size=1)
         self.pool2 = MaxAbsPool2d(kernel_size=2, stride=2)
 
         self.scs3_depth = SharpCosSim2d(
-            n_channels_in=n_kernels,
-            n_kernels=n_kernels,
+            in_channels=n_kernels,
+            out_channels=n_kernels,
             kernel_size=kernel_size,
-            depthwise=True)
+            groups=n_kernels)
         self.scs3_point = SharpCosSim2d(
-            n_channels_in=n_kernels,
-            n_kernels=n_kernels,
+            in_channels=n_kernels,
+            out_channels=n_kernels,
             kernel_size=1)
         self.pool3 = MaxAbsPool2d(kernel_size=4, stride=4)
 

--- a/pytorch/demo_fashion_mnist_lightning.py
+++ b/pytorch/demo_fashion_mnist_lightning.py
@@ -36,7 +36,7 @@ class FashionMNISTDataModule(pl.LightningDataModule):
     def __init__(self, data_dir: str = "./data/FashionMNIST", batch_size: int = 32):
         super().__init__()
         self.data_dir = data_dir
-        self.batch_size = batch_size        
+        self.batch_size = batch_size
 
     def setup(self, stage = None):
 
@@ -106,7 +106,6 @@ class SCSLNet(pl.LightningModule):
 
     def on_validation_epoch_end(self):
         # empty print for newline   
-        
         if self.epoch >= 0:
             tqdm.write(f"Epoch: {self.epoch}")
             tqdm.write(f"train loss: {np.mean(self.step_logs['train_loss']):06.2f}")

--- a/pytorch/sharpened_cosine_similarity.py
+++ b/pytorch/sharpened_cosine_similarity.py
@@ -20,8 +20,8 @@ class SharpCosSim2d(nn.Conv2d):
         log_q_init: float=1.,
         log_p_scale: float=5.,
         log_q_scale: float=.3,
-        alpha: Optional[float] = None,
-        autoinit: bool = False,
+        alpha: Optional[float]=10,
+        autoinit: bool=True,
         eps: float=1e-6,
     ):
         assert groups == 1 or groups == in_channels, " ".join([
@@ -105,8 +105,10 @@ class SharpCosSim2d(nn.Conv2d):
         inp = torch.rand(BS, CH, H, W, device=device)
         with torch.no_grad():
             out = self.forward(inp)
-            coef = out.std(dim=(0, 2, 3)) + self.eps
+            coef = (out.std(dim=(0, 2, 3)) + self.eps).mean()
             self.alpha.data *= 1.0 / coef.view_as(self.alpha)
+            print("initializing alpha to")
+            print(self.alpha)
         return
 
     def forward(self, inp: torch.Tensor) -> torch.Tensor:

--- a/pytorch/sharpened_cosine_similarity.py
+++ b/pytorch/sharpened_cosine_similarity.py
@@ -21,7 +21,7 @@ class SharpCosSim2d(nn.Conv2d):
         log_p_scale: float=5.,
         log_q_scale: float=.3,
         alpha: Optional[float]=10,
-        autoinit: bool=True,
+        alpha_autoinit: bool=False,
         eps: float=1e-6,
     ):
         assert groups == 1 or groups == in_channels, " ".join([
@@ -89,13 +89,11 @@ class SharpCosSim2d(nn.Conv2d):
         self.eps = eps
 
         if alpha is not None:
-            # self.alpha = torch.nn.Parameter(torch.full((self.out_channels,),
-            #                            float(alpha)))
             self.alpha = torch.nn.Parameter(torch.full(
                 (1, 1, 1, 1), float(alpha)))
         else:
             self.alpha = None
-        if autoinit and (alpha is not None):
+        if alpha_autoinit and (alpha is not None):
             self.LSUV_like_init()
 
     def LSUV_like_init(self):
@@ -107,8 +105,6 @@ class SharpCosSim2d(nn.Conv2d):
             out = self.forward(inp)
             coef = (out.std(dim=(0, 2, 3)) + self.eps).mean()
             self.alpha.data *= 1.0 / coef.view_as(self.alpha)
-            print("initializing alpha to")
-            print(self.alpha)
         return
 
     def forward(self, inp: torch.Tensor) -> torch.Tensor:

--- a/pytorch/sharpened_cosine_similarity.py
+++ b/pytorch/sharpened_cosine_similarity.py
@@ -15,13 +15,13 @@ class SharpCosSim2d(nn.Conv2d):
         padding: int=0,
         stride: int=1,
         groups: int=1,
-        shared_weights: bool = True,
+        shared_weights: bool = False,
         log_p_init: float=.7,
         log_q_init: float=1.,
         log_p_scale: float=5.,
         log_q_scale: float=.3,
         alpha: Optional[float] = None,
-        autoinit: bool = True,
+        autoinit: bool = False,
         eps: float=1e-6,
     ):
         assert groups == 1 or groups == in_channels, " ".join([
@@ -89,8 +89,10 @@ class SharpCosSim2d(nn.Conv2d):
         self.eps = eps
 
         if alpha is not None:
-            self.alpha = torch.nn.Parameter(torch.full((self.out_channels,),
-                                        float(alpha)))
+            # self.alpha = torch.nn.Parameter(torch.full((self.out_channels,),
+            #                            float(alpha)))
+            self.alpha = torch.nn.Parameter(torch.full(
+                (1, 1, 1, 1), float(alpha)))
         else:
             self.alpha = None
         if autoinit and (alpha is not None):


### PR DESCRIPTION
Playing with alpha, I found very strong results with 1 shared alpha value across the layer. Initial observations suggest that one alpha per kernel doesn't add anything to performance, while incurring the addition of extra parameters.

Inspecting the alpha values chosen by LSUV_like_init(), they fall roughly on the range from 10-50 for a small model I'm running on Fashion MNIST. Choosing an initial alpha of 10 and disabling auto init generates the strongest results I've seen from my model yet.

@ducha-aiki, what do you think about moving to a single alpha per layer and removing the LSUV init? You've spent the most time thinking about it, so it's possible you've built an intuition around it I don't have yet.

@4rtemi5 based on what I've seen, the alpha boosts performance noticeably. Based on what implementation we settle on in PyTorch I plan to mimic it in the Jax code. It *might* make a difference in getting to 90% on CIFAR-10.  

This diff is a little messy-it also has some changes to the demo scripts to make them compatible with the new API.